### PR TITLE
Weapon class updates

### DIFF
--- a/src/weapons/falchion.json
+++ b/src/weapons/falchion.json
@@ -412,6 +412,7 @@
   "subclasses": [
     "Skirmisher",
     "Man at Arms",
-    "Crusader"
+    "Crusader",
+    "Guardian"
   ]
 }

--- a/src/weapons/heavy_cavalry_sword.json
+++ b/src/weapons/heavy_cavalry_sword.json
@@ -462,6 +462,7 @@
     "Knight"
   ],
   "subclasses": [
-    "Guardian"
+    "Guardian",
+    "Man at Arms"
   ]
 }

--- a/src/weapons/quarterstaff.json
+++ b/src/weapons/quarterstaff.json
@@ -458,9 +458,11 @@
     }
   },
   "classes": [
-    "Knight"
+    "Knight",
+    "Footman"
   ],
   "subclasses": [
-    "Officer"
+    "Crusader",
+    "Poleman"
   ]
 }


### PR DESCRIPTION
This changes the class field for 3 weapons, aligning them with the current in-game weapon options:
Add "Man at Arms" to heavy cavalry sword.json
Add "Guardian" to falchion.json
Add "Crusader" and "Poleman" to quarterstaff.json
Remove "Officer" from quarterstaff.json